### PR TITLE
Simulation changes to allow running multiple times

### DIFF
--- a/roboRIO-2024/src/main/java/frc/robot/simulation/RelativeEncoderSim.java
+++ b/roboRIO-2024/src/main/java/frc/robot/simulation/RelativeEncoderSim.java
@@ -30,7 +30,7 @@ public class RelativeEncoderSim implements RelativeEncoder {
     }
 
     public void setSimulationPositionMeters(double position) {
-        m_simulationPostion = position;
+        m_simulationPostion = position + m_offset;
     }
     
     public void zeroSimulationPostion() {

--- a/roboRIO-2024/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/roboRIO-2024/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -25,6 +25,7 @@ import edu.wpi.first.units.Voltage;
 import edu.wpi.first.util.datalog.DataLog;
 import edu.wpi.first.util.datalog.DoubleLogEntry;
 import edu.wpi.first.wpilibj.DataLogManager;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.simulation.DifferentialDrivetrainSim;
@@ -184,9 +185,11 @@ public class Drivetrain extends SubsystemBase {
 
   @Override
   public void simulationPeriodic() {
-    m_odometry.simulationPeriodic();
-    m_simulation.setInputs(leftLeader.get() * RobotController.getBatteryVoltage(), rightLeader.get() * RobotController.getBatteryVoltage());
-    m_simulation.update(0.02);
+    if (!DriverStation.isDisabled()) {
+      m_odometry.simulationPeriodic();
+      m_simulation.setInputs(leftLeader.get() * RobotController.getBatteryVoltage(), rightLeader.get() * RobotController.getBatteryVoltage());
+      m_simulation.update(0.02);
+    }
   }
 
   DifferentialDrivetrainSim getSimulation() {

--- a/roboRIO-2024/src/main/java/frc/robot/subsystems/OdometrySubsystem.java
+++ b/roboRIO-2024/src/main/java/frc/robot/subsystems/OdometrySubsystem.java
@@ -9,6 +9,8 @@ import com.pathplanner.lib.util.ReplanningConfig;
 import com.revrobotics.REVLibError;
 import com.revrobotics.RelativeEncoder;
 
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -131,7 +133,7 @@ public class OdometrySubsystem {
     rightEncoderVelocityEntry.append(m_rightEncoder.getVelocity());
 
   }
-  
+
   public void resetPose(Pose2d newPose) {
     gyro.reset();
     REVLibError errorLeft = m_leftEncoder.setPosition(0);
@@ -141,13 +143,12 @@ public class OdometrySubsystem {
     SmartDashboard.putString("Right errror", errorRight.toString());
 
     m_odometry = new DifferentialDriveOdometry(
-          getRotation(),
+          new Rotation2d(),
           0, 0,
           newPose);
     pose = m_odometry.getPoseMeters();
-    if (Robot.isSimulation()) {
-      drivetrain.getSimulation().setPose(pose);
-    }
+
+
 
     SmartDashboard.putNumber("Rotation via pose at reset", pose.getRotation().getDegrees());
     SmartDashboard.putNumber("Left Encoder Position at reset", m_leftEncoder.getPosition());
@@ -155,6 +156,12 @@ public class OdometrySubsystem {
     SmartDashboard.putNumber("Pose x at reset", pose.getX());
     SmartDashboard.putNumber("Pose y at reset", pose.getY());
     SmartDashboard.putNumber("Gyro rotation at reset", getRotation().getDegrees());
+
+    if (Robot.isSimulation()) {
+      drivetrain.getSimulation().setPose(pose);
+      // set enocder positions/velocity to 0
+      drivetrain.getSimulation().setState(new Matrix<>(Nat.N7(), Nat.N1()));
+    }
   }
 
 //   public void resetPose(Pose2d pose) {


### PR DESCRIPTION
This changes the simulation code to fix an issue where the simulation wouldn't work if you ran the autonomous multiple times. In order to do the, it resets the simulation drivetrain pose to the odometry pose, and fixes a bug in RelativeEncoderSim.